### PR TITLE
[fix]: fix http challenge

### DIFF
--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -14,7 +14,7 @@
         --server='{{ lets_encrypt_server }}' \
         --filename='{{ item.item.common_name }}' \
         {% if item.item.challenge == 'dns' %}--dns='{{ item.item.provider }}'{% endif %} \
-        {% if item.item.challenge == 'http' %}--webroot='{{ item.item.webroot }}'{% endif %} \
+        {% if item.item.challenge == 'http' %}--http --http.webroot='{{ item.item.webroot }}'{% endif %} \
         -a
         run"
   with_items: "{{ lets_encrypt_resources_stat.results }}"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -10,7 +10,7 @@
           --server='{{ lets_encrypt_server }}' \
           --filename='{{ item.common_name }}' \
           {% if item.challenge == 'dns' %}--dns='{{ item.provider }}'{% endif %} \
-          {% if item.challenge == 'http' %}--webroot='{{ item.webroot }}'{% endif %} \
+          {% if item.challenge == 'http' %}--http --http.webroot='{{ item.webroot }}'{% endif %} \
           renew \
           --days {{ lets_encrypt_renew_limit }}"
     minute: "{{ lets_encrypt_cron_minute | default('0') }}"


### PR DESCRIPTION
  The systax for the certificate creation and renewal does not work with current versions
  of lego.

  This commit fixes the issue by changing it to the currently supported syntax