### PR TITLE
[feat]: silence cron jobs

### DIFF
--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -12,7 +12,8 @@
           {% if item.challenge == 'dns' %}--dns='{{ item.provider }}'{% endif %} \
           {% if item.challenge == 'http' %}--http --http.webroot='{{ item.webroot }}'{% endif %} \
           renew \
-          --days {{ lets_encrypt_renew_limit }}"
+          --days {{ lets_encrypt_renew_limit }} \
+          > /dev/null"
     minute: "{{ lets_encrypt_cron_minute | default('0') }}"
     hour: "{{ lets_encrypt_cron_hour | default('11') }}"
     weekday: "{{ lets_encrypt_cron_weekday | default(omit) }}"


### PR DESCRIPTION
I don't want to have emails every morning that some project's certifcate
was or wasn't removed, it is ok to see that when we are debugging
things, but not on daily operation.

More generally we should follow black cockpit approach everywhere:

* if things are ok - no lights are lit, (hence the name is "black"),
  i.e. no emails or alerts.
* if there are errors or warnings - we see warning lights,
  i.e. we receive monitoring alerts and/or emails

Silencing thestd out here, cause there is no way to lower verbosity of
lego client unfortunately.