### PR TITLE
[feat]: install cert as trusted when needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ lets_encrypt_renew_limit: 30
 
 # links the certificate to system CA folder,
 # to allow localhost connections when staging certs are used.
+# DO NOT USE ON PRODUCTION
 lets_encrypt_install_as_trusted: false
 
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ lets_encrypt_account_email: "mail@sitewards.com"
 # number of days before expiry the renewal will be performed
 lets_encrypt_renew_limit: 30
 
+# links the certificate to system CA folder,
+# to allow localhost connections when staging certs are used.
+lets_encrypt_install_as_trusted: false
+
 #
 # Optional cron expression variables
 #

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: "Update CA index"
+  shell: /usr/sbin/update-ca-certificates

--- a/tasks/add-staging-as-trusted.yml
+++ b/tasks/add-staging-as-trusted.yml
@@ -1,0 +1,41 @@
+- name: "add folder for staging CA files"
+  file:
+      path: "/usr/local/share/ca-certificates/letsencrypt-staging/"
+      state: "directory"
+  become: true
+
+- name: "Download let's encrypt RSA intermedia cert"
+  get_url:
+      url: "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
+      dest: "/usr/local/share/ca-certificates/letsencrypt-staging/letsencrypt-stg-int-r3.crt"
+      checksum: "sha256:a7b89d7955532169a3660865f5e394aa0e180c4d00ca02ebd677ad07242b2150"
+      mode: 0644
+  become: true
+  notify: "Update CA index"
+
+- name: "Download let's encrypt ECDSA intermedia cert"
+  get_url:
+      url: "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
+      dest: "/usr/local/share/ca-certificates/letsencrypt-staging/letsencrypt-stg-int-e1.crt"
+      checksum: "sha256:a67504501308ffa5ba2a9e1f9dd4fd19aabc8918e29bc9dc2074209533140208"
+      mode: 0644
+  become: true
+  notify: "Update CA index"
+
+- name: "Download let's encrypt RSA root cert"
+  get_url:
+      url: "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem"
+      dest: "/usr/local/share/ca-certificates/letsencrypt-staging/letsencrypt-stg-root-x1.crt"
+      checksum: "sha256:3a5e1171e5f5c2d41522d438f225602e4236a68fb29c32399a95921a4ae80e73"
+      mode: 0644
+  become: true
+  notify: "Update CA index"
+
+- name: "Download let's encrypt ECDSA root cert"
+  get_url:
+      url: "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x2.pem"
+      dest: "/usr/local/share/ca-certificates/letsencrypt-staging/letsencrypt-stg-root-x2.crt"
+      checksum: "sha256:497c36c1b50c0daff30870d5908c9b97af29223d5510c5e6c24957d0cc502fb8"
+      mode: 0644
+  become: true
+  notify: "Update CA index"

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -38,3 +38,13 @@
   when:
     - lets_encrypt_resource is not skipped
     - ( lets_encrypt_resource_stat_result.stat.exists == false ) or ( lets_encrypt_ressource_validity_check.failed )
+
+- name: "install lets encrypt cert as trusted"
+  file:
+    src: "{{ lets_encrypt_directory_path }}/certificates/{{ lets_encrypt_resource.common_name }}.issuer.crt"
+    path: "/usr/local/share/ca-certificates/{{ lets_encrypt_resource.common_name }}.issuer.crt"
+    state: "link"
+  become: true
+  when: lets_encrypt_install_as_trusted
+  notify: "Update CA index"
+

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -38,13 +38,3 @@
   when:
     - lets_encrypt_resource is not skipped
     - ( lets_encrypt_resource_stat_result.stat.exists == false ) or ( lets_encrypt_ressource_validity_check.failed )
-
-- name: "install lets encrypt cert as trusted"
-  file:
-    src: "{{ lets_encrypt_directory_path }}/certificates/{{ lets_encrypt_resource.common_name }}.issuer.crt"
-    path: "/usr/local/share/ca-certificates/{{ lets_encrypt_resource.common_name }}.issuer.crt"
-    state: "link"
-  become: true
-  when: lets_encrypt_install_as_trusted
-  notify: "Update CA index"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,6 @@
       loop_var: "lets_encrypt_resource"
 
 - include: "cron.yml"
+
+- include: "add-staging-as-trusted.yml"
+  when: lets_encrypt_install_as_trusted


### PR DESCRIPTION
when we use staging API, resulting cert is not added to CAs.
In order to allow server connecting to itself - need to let it trust
itself, e.g. when calling REST API on localhost.